### PR TITLE
add missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "sass-resources-loader"
   ],
   "dependencies": {
-    "sass-resources-loader": "^2.0.0"
+    "sass-resources-loader": "^2.0.0",
+    "node-sass": "^4.12.0",
+    "sass-loader": "^7.1.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The two dependencies must be installed for the plugin to work properly. I couldn't get it working for a while because of this until I found it in your example.